### PR TITLE
Add support for the sha256 algorithm....

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -199,7 +199,7 @@ def login(request,
         try:
             session_id, result = client.prepare_for_authenticate(
                 entityid=selected_idp, relay_state=came_from,
-                binding=binding, sign=False, sig_alg=sigalg, digest_alg=digalg)
+                binding=binding, sign=False, sign_alg=sigalg, digest_alg=digalg)
         except TypeError as e:
             logger.error('Unable to know which IdP to use')
             return HttpResponse(text_type(e))


### PR DESCRIPTION
These changes are needed to add support to be able to pick the rsa-sha256 and digest-sha256 algorithms. All the heavy lifting is in the pysaml2 package, but there needs to be a way to signal this to the pysaml2 package.

This needs testing against ADFS which only supports sha256.